### PR TITLE
make event fields work a little better

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,10 +439,10 @@ impl Sentry {
                 }
             };
 
-            let e = Event::new(&location,
+            let e = Event::new("panic",
                                "fatal",
                                msg,
-                               None,
+                               Some(&location),
                                Some(&server_name),
                                Some(&release),
                                Some(&environment));


### PR DESCRIPTION
looks like sentry doesn't like loggers that have spaces in them. We should instead put the file/line in the "culprit" field. the sentry UI seems to like it when you use the culprit field, as it sticks its contents right below the name of the message.
![screen shot 2016-08-11 at 2 22 14 pm](https://cloud.githubusercontent.com/assets/902007/17605383/11565824-5fcf-11e6-8f36-379427ef6003.png)
