### PR TITLE
include stack trace in event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ Sentry (getsentry.com) client for rust ;)
 
 
 [dependencies]
+backtrace = "0.2"
 hyper = "0.9.5"
 time = "0.1.35"
 chrono = "0.2.22"


### PR DESCRIPTION
sentry output:

![screen shot 2016-10-19 at 2 14 40 pm](https://cloud.githubusercontent.com/assets/902007/19537855/6df7a264-9606-11e6-952b-2f913e396a01.png)
